### PR TITLE
Fix Octane

### DIFF
--- a/src/MemoizedClientRepository.php
+++ b/src/MemoizedClientRepository.php
@@ -5,7 +5,7 @@ namespace Stayallive\Laravel\Passport\Memoized;
 use Laravel\Passport\Client;
 use Laravel\Passport\ClientRepository;
 
-class MemoizedClientRepository extends ClientRepository
+class MemoizedClientRepository extends ClientRepository implements MemoizedRepository
 {
     private array $cache = [];
 
@@ -50,5 +50,10 @@ class MemoizedClientRepository extends ClientRepository
         unset($this->cache[$client->id]);
 
         parent::delete($client);
+    }
+
+    public function clearInternalCache(): void
+    {
+        $this->cache = [];
     }
 }

--- a/src/MemoizedRepository.php
+++ b/src/MemoizedRepository.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Stayallive\Laravel\Passport\Memoized;
+
+interface MemoizedRepository
+{
+    public function clearInternalCache(): void;
+}

--- a/src/MemoizedTokenRepository.php
+++ b/src/MemoizedTokenRepository.php
@@ -5,7 +5,7 @@ namespace Stayallive\Laravel\Passport\Memoized;
 use Laravel\Passport\Token;
 use Laravel\Passport\TokenRepository;
 
-class MemoizedTokenRepository extends TokenRepository
+class MemoizedTokenRepository extends TokenRepository implements MemoizedRepository
 {
     private array $cache = [];
 
@@ -39,5 +39,10 @@ class MemoizedTokenRepository extends TokenRepository
         unset($this->cache[$id]);
 
         return parent::revokeAccessToken($id);
+    }
+
+    public function clearInternalCache(): void
+    {
+        $this->cache = [];
     }
 }

--- a/src/OctaneOperationTerminatedListener.php
+++ b/src/OctaneOperationTerminatedListener.php
@@ -10,7 +10,16 @@ class OctaneOperationTerminatedListener
 {
     public function handle(OperationTerminated $event): void
     {
-        $event->app->forgetInstance(TokenRepository::class);
-        $event->app->forgetInstance(ClientRepository::class);
+        $repositories = [
+            $event->app()->make(TokenRepository::class),
+            $event->app()->make(ClientRepository::class),
+        ];
+
+        foreach ($repositories as $repository) {
+            if ($repository instanceof MemoizedRepository) {
+                $repository->clearInternalCache();
+            }
+        }
     }
+
 }

--- a/src/OctaneOperationTerminatedListener.php
+++ b/src/OctaneOperationTerminatedListener.php
@@ -4,11 +4,11 @@ namespace Stayallive\Laravel\Passport\Memoized;
 
 use Laravel\Passport\TokenRepository;
 use Laravel\Passport\ClientRepository;
-use Laravel\Octane\Events\TaskTerminated;
+use Laravel\Octane\Contracts\OperationTerminated;
 
-class OctaneTaskTerminatedListener
+class OctaneOperationTerminatedListener
 {
-    public function handle(TaskTerminated $event): void
+    public function handle(OperationTerminated $event): void
     {
         $event->app->forgetInstance(TokenRepository::class);
         $event->app->forgetInstance(ClientRepository::class);

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -6,13 +6,19 @@ use Illuminate\Events\Dispatcher;
 use Laravel\Passport\TokenRepository;
 use Laravel\Passport\ClientRepository;
 use Laravel\Octane\Events\TaskTerminated;
+use Laravel\Octane\Events\TickTerminated;
+use Laravel\Octane\Events\RequestTerminated;
 use Illuminate\Support\ServiceProvider as LaravelServiceProvider;
 
 class ServiceProvider extends LaravelServiceProvider
 {
     public function boot(Dispatcher $events): void
     {
-        $events->listen(TaskTerminated::class, OctaneTaskTerminatedListener::class);
+        $events->listen([
+            TickTerminated::class,
+            TaskTerminated::class,
+            RequestTerminated::class,
+        ], OctaneOperationTerminatedListener::class);
     }
 
     public function register(): void


### PR DESCRIPTION
The token cache is not cleared on every request on Octane, this is either because Passport is holding a reference or the `TaskTerminated` event is not enough to correctly clear the memoized cache every request.

So going of the [Octane config](https://github.com/laravel/octane/blob/577cc8dc3d1f7675124d5d8214f08224e0271d03/config/octane.php#L103-L107) file we now listen to all `OperationTerminated` events which should solve the issue where the cache is not always flushed correctly after handling a tick/request/task.

In addition we no longer clear the instance from the container but instead clear the cache from the memoized repositories so anyone holding a reference will also have it's cache cleared.

The result was that when a token was revoked or removed from the database it could stay active longer than intended, when running in Laravel Octane.