### PR TITLE
Cache client when it's fetched from first personalAccessClient

### DIFF
--- a/src/MemoizedClientRepository.php
+++ b/src/MemoizedClientRepository.php
@@ -27,6 +27,17 @@ class MemoizedClientRepository extends ClientRepository implements MemoizedRepos
             : null;
     }
 
+    public function personalAccessClient(): Client
+    {
+        $client = parent::personalAccessClient();
+
+        if ($client !== null) {
+            $this->cache[$client->id] = $client;
+        }
+
+        return $client;
+    }
+
     public function update(Client $client, $name, $redirect): Client
     {
         $client = parent::update($client, $name, $redirect);
@@ -55,12 +66,5 @@ class MemoizedClientRepository extends ClientRepository implements MemoizedRepos
     public function clearInternalCache(): void
     {
         $this->cache = [];
-    }
-
-    public function personalAccessClient(): Client
-    {
-        $client = parent::personalAccessClient();
-        $this->cache[$client->id] = $client;
-        return $client;
     }
 }

--- a/src/MemoizedClientRepository.php
+++ b/src/MemoizedClientRepository.php
@@ -56,4 +56,11 @@ class MemoizedClientRepository extends ClientRepository implements MemoizedRepos
     {
         $this->cache = [];
     }
+
+    public function personalAccessClient(): Client
+    {
+        $client = parent::personalAccessClient();
+        $this->cache[$client->id] = $client;
+        return $client;
+    }
 }


### PR DESCRIPTION
In my project I'm using `createToken` function from `HasApiTokens` trait and **_laravel-passport-memoized_** is used to avoid duplicated db queries caused by _**Passport**_.
But there still a duplicated query as the following:

<img width="1186" alt="Screenshot 2024-04-01 at 2 05 40 pm" src="https://github.com/stayallive/laravel-passport-memoized/assets/111225558/919d39a2-382a-405a-aeb5-010691ec4deb">

Both queries are called by `ClientRepository` class's functions, first one is called by `find` and second by `personalAccessClient`.
Currently, `personalAccessClient` is not caching, so this pull request add an override to this function in order to cache the client when fetched.